### PR TITLE
[3.0.0-preview] Porting to System.Reactive

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -26,7 +26,7 @@ $nuspec = Join-Path (Get-ScriptDirectory) src\Reactive.EventAggregator\Reactive.
 $nugetVersion = $env:APPVEYOR_BUILD_VERSION 
 if ($nugetVersion -eq $null)
 {
-   $nugetVersion = "2.0.0"
+   $nugetVersion = "3.0.0-preview"
 }
 
 . $nuget pack $nuspec -Version $nugetVersion

--- a/src/Reactive.EventAggregator.Tests/Reactive.EventAggregator.Tests.csproj
+++ b/src/Reactive.EventAggregator.Tests/Reactive.EventAggregator.Tests.csproj
@@ -103,18 +103,10 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
     <Error Condition="!Exists('..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\xunit.core.2.1.0\build\portable-net45+win8+wp8+wpa81\xunit.core.props'))" />
   </Target>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/src/Reactive.EventAggregator/EventAggregator.Portable.csproj
+++ b/src/Reactive.EventAggregator/EventAggregator.Portable.csproj
@@ -61,12 +61,4 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
-  <Import Project="$(SolutionDir)\.nuget\nuget.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/src/Reactive.EventAggregator/Reactive.EventAggregator.nuspec
+++ b/src/Reactive.EventAggregator/Reactive.EventAggregator.nuspec
@@ -10,7 +10,7 @@
     <description>A portable EventAggregator based on Rx for .NET 4.0+, WP8 and Windows Store Apps</description>
     <copyright>Copyright © 2013</copyright>
     <dependencies>
-      <dependency id="Rx-Linq" version="2.2.5" />
+      <dependency id="System.Reactive.Linq" version="[3.0.0,4.0.0)" />
     </dependencies>
   </metadata>
 


### PR DESCRIPTION
Here's the list of changes I needed to do to cut a pre-release package. Most of it was related to `nuget.targets` which we're now moving away from, so it's not stuff I'm worried about.

```
Unable to find version '2.1.0' of package 'xunit.runner.console'.
```

This is listed under the `.nuget/packages.config`, not really sure why it's needed because it's not used.


```
C:\Users\shiftkey\Documents\GitHub\Reactive.EventAggregator\src\.nuget\nuget.targets(70,9): error MSB4175: The task fac
tory "CodeTaskFactory" could not be loaded from the assembly "C:\Program Files (x86)\MSBuild\12.0\bin\Microsoft.Build.T
asks.v4.0.dll". Could not load file or assembly 'file:///C:\Program Files (x86)\MSBuild\12.0\bin\Microsoft.Build.Tasks.
v4.0.dll' or one of its dependencies. The system cannot find the file specified. [C:\Users\shiftkey\Documents\GitHub\Re
active.EventAggregator\src\Reactive.EventAggregator.Tests\Reactive.EventAggregator.Tests.csproj]
```

Some component inside `nuget.targets` looking for something I don't have on this VS2015-only VM. Oh well.

Anyway, it's available here if you want to try it out: https://www.nuget.org/packages/Reactive.EventAggregator/3.0.0-preview

cc @BrainCrumbz 