### PR TITLE
drop the pre-release flag

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -61,7 +61,7 @@ Task("Package")
 {
   var nuGetPackSettings   = new NuGetPackSettings
   {
-    Version                 = "3.0.0-preview2",
+    Version                 = "3.0.0",
     ProjectUrl              = new Uri("https://github.com/shiftkey/Reactive.EventAggregator/"),
     // TODO: an icon?
     //IconUrl                 = new Uri("http://cdn.rawgit.com/SomeUser/TestNuget/master/icons/testnuget.png"),


### PR DESCRIPTION
There's probably some other cleanup needed in here, but given I've heard nothing since publishing this with Rx v3 support I'm going to assume things are okay.